### PR TITLE
Added additional info for chain such as total circulating supply

### DIFF
--- a/src/general/index.js
+++ b/src/general/index.js
@@ -59,7 +59,7 @@ const influx = new Influx.InfluxDB({
             tags: ["host"]
         },
 	{
-	measurement: 'gettxoutsetinfo;,
+	measurement: 'gettxoutsetinfo',
 		fields: {
 		total_amount: Influx.FieldType.INTEGER,
 		transactions: Influx.FieldType.INTEGER,

--- a/src/general/index.js
+++ b/src/general/index.js
@@ -57,14 +57,24 @@ const influx = new Influx.InfluxDB({
                 connections: Influx.FieldType.INTEGER,
             },
             tags: ["host"]
-        }
+        },
+	{
+	measurement: 'gettxoutsetinfo;,
+		fields: {
+		total_amount: Influx.FieldType.INTEGER,
+		transactions: Influx.FieldType.INTEGER,
+		txouts: Influx.FieldType.INTEGER,
+		disk_size: Influx.FieldType.INTEGER
+		},
+		tags: ["host"]
+	}
     ]
    })
    
 const client = new Client(clientSettings)
 
 new CronJob('* * * * *', () => {
-  Promise.all([ client.send('getinfo'), client.send('getmempoolinfo'), client.send('getallnetworkhashps'), client.send('getnetworkinfo')]).then(([info, mempool, hash, network]) => {
+  Promise.all([ client.send('getinfo'), client.send('getmempoolinfo'), client.send('getallnetworkhashps'), client.send('getnetworkinfo'), client.send('gettxoutsetinfo')]).then(([info, mempool, hash, network, gettxoutsetinfo]) => {
     return influx.writePoints([
         {
             measurement: 'info',
@@ -116,7 +126,17 @@ new CronJob('* * * * *', () => {
               timeoffset: network.timeoffset,
               connections: network.connections,
             },
-        }
+        },
+	{
+		measurement: 'gettxoutsetinfo',
+		tags: { host: 'verge' },
+		fields: {
+			total_amount: gettxoutsetinfo.total_amount,
+			transactions: gettxoutsetinfo.transactions,
+			txouts: gettxoutsetinfo.txouts,
+			disk_size: gettxoutsetinfo.disk_size
+		},
+	}
       ]).catch(console.error)
   }).then(() => console.log("Wrote points to database.")).catch(console.error)
 }, null, true, 'America/Los_Angeles')


### PR DESCRIPTION
Details include:
total_amount for Circulating Supply
transactions for Transactions
txouts for # of transaction outputs
disk_size for size on-disk

Requires blockchain-cli interfacing with daemon on BTC Core 0.16 or newer: https://bitcoincore.org/en/doc/0.16.0/rpc/blockchain/gettxoutsetinfo/